### PR TITLE
Bump targetSdk to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.3.2"
 
 android-sdk-compile = "37"
-android-sdk-target = "36"
+android-sdk-target = "37"
 android-sdk-min = "23"
 
 androidx-activity = "1.13.0"


### PR DESCRIPTION
Follow-up to #645.

That PR raised `compileSdk` to 37 because androidx.compose 1.12.0's AAR metadata requires consumers to compile against API 37 or later, but left `targetSdk` at 36. This brings the two back in line.

```diff
 android-sdk-compile = "37"
-android-sdk-target = "36"
+android-sdk-target = "37"
 android-sdk-min = "23"
```

### Why this is separate from #645

Only `compileSdk` was required to fix that build. Raising `targetSdk` opts the app into Android API 37 runtime behavior changes, which is a behavioral change rather than a build fix — worth landing on its own so the behavior delta gets looked at independently of the dependency bump.

### Scope

In practice this affects `sample/android-app` only. AGP applies `targetSdk` to library modules for instrumented tests, so the published library artifacts are unchanged by this.

The sample's manifest declares nothing gated on target API level (no `android:targetApi` attributes, no opt-outs), and the app is a single activity hosting the shared Compose UI, so no accompanying source changes are needed.

### Verification

Not built locally — this environment's network policy blocks `maven.google.com`, `dl.google.com`, and `services.gradle.org`, so no Gradle run was possible. CI is the first real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KoHgDhTmNhFNToqizqEV2)_